### PR TITLE
fix: correct date parsing for week navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   TZ_NY,
   fmtISO,
   addDays,
+  parseISODateLocal,
   startOfWeekInTZ,
   TIMES,
   keyHM,
@@ -33,14 +34,14 @@ export default function App() {
   const weekStartLabel = useMemo(
     () =>
       startOfWeekInTZ(
-        new Date(dateInput + "T00:00:00"),
+        parseISODateLocal(dateInput),
         viewTZ === "EST" ? TZ_NY : TZ_PH
       ),
     [dateInput, viewTZ]
   );
 
   const weekStartLocal = useMemo(
-    () => startOfWeekInTZ(new Date(dateInput + "T00:00:00"), localTZ),
+    () => startOfWeekInTZ(parseISODateLocal(dateInput), localTZ),
     [dateInput, localTZ]
   );
   const wkKey = fmtISO(weekStartLocal);
@@ -138,7 +139,7 @@ export default function App() {
                 min={fmtISO(minDate)}
                 max={fmtISO(maxDate)}
                 onChange={(e) => {
-                  const next = startOfWeekInTZ(new Date(e.target.value + "T00:00:00"), localTZ);
+                  const next = startOfWeekInTZ(parseISODateLocal(e.target.value), localTZ);
                   if (next < minDate || next > maxDate) return;
                   setDateInput(fmtISO(next));
                 }}

--- a/src/PlannerCell.tsx
+++ b/src/PlannerCell.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { Cell } from "./types";
-import { useAutoFit } from "./src/hooks/useAutoFit"; // Keep the reusable hook
+import { useAutoFit } from "./hooks/useAutoFit"; // Keep the reusable hook
 
 export function PlannerCell({
   value,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,11 @@ export function fmtISO(d: Date) {
   const local = new Date(d.getTime() - offset * 60000);
   return local.toISOString().slice(0, 10);
 }
+
+export function parseISODateLocal(iso: string) {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
 export function addDays(d: Date, n: number) {
   const x = new Date(d);
   x.setDate(x.getDate() + n);


### PR DESCRIPTION
## Summary
- fix date parsing so week navigation works reliably across time zones
- repair PlannerCell hook import path

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c809061c4832db02a1a0f91cc0c7f