### PR TITLE
feat: add week number dropdown and simplify timezone

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,14 @@ export function startOfWeekInTZ(date: Date, timeZone: string) {
   return out;
 }
 
+export function getWeekNumber(date: Date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
 export const TIMES: { h: number; m: number }[] = [];
 for (let h = 5; h <= 23; h++) {
   TIMES.push({ h, m: 0 });


### PR DESCRIPTION
## Summary
- replace date picker with week number selector
- stop shifting slots when viewing in another timezone
- expose utility to compute ISO week numbers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d896dfc28832d9451a45ad5e68359